### PR TITLE
fix(): Fix body of request

### DIFF
--- a/src/makeMultipartMixedRequest/handlebarsTemplates.ts
+++ b/src/makeMultipartMixedRequest/handlebarsTemplates.ts
@@ -19,10 +19,9 @@ Accept: application/json
 {{@key}}: {{this}}
 {{/each}}
 {{#if body}}
-Content-Type: application/json
-{{{json body}}}
-{{/if}}
 
+{{{body}}}
+{{/if}}
 
 {{/each}}
 {{#if requests}}


### PR DESCRIPTION
This PR fixed #4 error.

I was checking and debugging this and notice multiple things:

1. The `Content-Type` header was duplicated (it is already included in the headers)
2. The body is already `json` when it ends on `handlebars` template
3. There should be an space between headers and body (if any)
4. There should be only one line between end of boundary and the body