### PR TITLE
Add types to package.json exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Permits type declaration discovery when a consumer has `moduleResolution: node16` in their tsconfig and `type: module` in their `package.json`